### PR TITLE
Add template option

### DIFF
--- a/lib/gnucash/invoice/printer.rb
+++ b/lib/gnucash/invoice/printer.rb
@@ -6,8 +6,9 @@ require 'sprockets'
 module GnuCash
   class Invoice
     class Printer
-      def initialize invoice_id
+      def initialize invoice_id, template_path
         @invoice = Invoice.find(invoice_id)
+        @template_path = template_path.nil? ? 'templates' : template_path
       end
 
 
@@ -39,7 +40,7 @@ module GnuCash
 
 
       def template_dir *args
-        args.unshift 'templates'
+        args.unshift @template_path
         GnuCash.root.join(*args)
       end
     end

--- a/lib/gnucash/invoice/runner.rb
+++ b/lib/gnucash/invoice/runner.rb
@@ -17,7 +17,7 @@ module GnuCash
 
         # Print out invoice
         unless argv.empty?
-          puts Printer.new(options.invoice_id).render
+          puts Printer.new(options.invoice_id, options.template_path).render
           exit
         end
 
@@ -37,6 +37,9 @@ module GnuCash
         OptionParser.new do |opts|
           opts.on('-d', '--dbpath [DATABASE]', 'SQLite database path') do |path|
             options.dbpath = Pathname.new path
+          end
+          opts.on('-t', '--template [TEMPLATE]', 'Template directory path') do |path|
+            options.template_path = Pathname.new path
           end
         end.parse! argv
 


### PR DESCRIPTION
Quick option to specify a path to a custom template directory. Currently expects
the given directory to match that of the default 'templates' directory (i.e.
contains 'invoice.slim' and 'asssets'); probably needs to be expanded on to
provide a more robust mechanism for custom templates.
